### PR TITLE
Removed keepdims parameter

### DIFF
--- a/spaceDust.ipynb
+++ b/spaceDust.ipynb
@@ -107,7 +107,7 @@
     "    masses_arr = np.tile(config.masses_, len(config.r_)).reshape(config.dir_ij_arr_.shape[:2] + (1,))\n",
     "    \n",
     "    dirs_m = config.dir_ij_arr_/norms*masses_arr\n",
-    "    config.F_ = np.dot(np.diag(config.masses_), (dirs_m/norms**2).sum(axis = 1, keepdims = True)[:,0,:])\n",
+    "    config.F_ = np.dot(np.diag(config.masses_), (dirs_m/norms**2).sum(axis = 1))\n",
     "    return config.F_"
    ]
   },


### PR DESCRIPTION
Notebook does not run for me otherwise. Maybe you have a different numpy version, mine is 1.11.

Fixes #1 